### PR TITLE
projects in terms of eproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "eproject"]
+	path = eproject
+	url = https://github.com/jrockway/eproject.git

--- a/README.markdown
+++ b/README.markdown
@@ -2,8 +2,8 @@ TextMate Minor Mode
 ===================
 
     ;; This minor mode exists to mimick TextMate's awesome
-    ;; features. 
-    
+    ;; features.
+
     ;;    ⌘T - Go to File
     ;;  ⇧⌘T - Go to Symbol
     ;;    ⌘L - Go to Line
@@ -17,7 +17,7 @@ TextMate Minor Mode
     ;;    ⌥↓ - Column Down
     ;;  ⌘RET - Insert Newline at Line's End
     ;;  ⌥⌘T - Reset File Cache (for Go to File)
-    
+
     ;; A "project" in textmate-mode is determined by the presence of
     ;; a .git directory, an .hg directory, a Rakefile, or a Makefile.
 
@@ -39,6 +39,7 @@ Installation
 
     $ cd ~/.emacs.d/vendor
     $ git clone git://github.com/defunkt/textmate.el.git
+    $ git submodule update
 
 In your emacs config:
 

--- a/eproject.el
+++ b/eproject.el
@@ -1,0 +1,1 @@
+eproject/eproject.el

--- a/textmate.el
+++ b/textmate.el
@@ -71,24 +71,42 @@
 
 ;;; Configurable variables
 
-(defvar *textmate-gf-exclude*
-  "(/|^)(\\.+[^/]+|vendor|fixtures|tmp|log|classes|build)($|/)|(\\.xcodeproj|\\.nib|\\.framework|\\.app|\\.pbproj|\\.pbxproj|\\.xcode|\\.xcodeproj|\\.bundle|\\.pyc)(/|$)"
-  "Regexp of files to exclude from `textmate-goto-file'.")
+(defgroup textmate.el nil
+  "textmate.el; minor mode to make Emacs more like TextMate"
+  :prefix "textmate-"
+  :group 'convenience
+  :link '(url-link :tag "Github repository" "https://github.com/defunkt/textmate.el"))
 
-(defvar *textmate-project-roots*
+(defcustom *textmate-gf-exclude*
+  "(/|^)(\\.+[^/]+|vendor|fixtures|tmp|log|classes|build)($|/)|(\\.xcodeproj|\\.nib|\\.framework|\\.app|\\.pbproj|\\.pbxproj|\\.xcode|\\.xcodeproj|\\.bundle|\\.pyc)(/|$)"
+  "Regexp of files to exclude from `textmate-goto-file'."
+  :group 'textmate.el
+  :type 'regexp)
+
+(defcustom *textmate-project-roots*
   '(".git" ".hg" "Rakefile" "Makefile" "README" "build.xml" ".emacs-project")
-  "The presence of any file/directory in this list indicates a project root.")
+  "The presence of any file/directory in this list indicates a project root."
+  :group 'textmate.el
+  :type '(repeat string))
 
 (define-project-type textmate-project (generic)
   (textmate-search-roots)
   :irrelevant-files (lambda (root) (list *textmate-gf-exclude*)))
 
-(defvar textmate-use-file-cache t
-  "Should `textmate-goto-file' keep a local cache of files?")
+(defcustom textmate-use-file-cache t
+  "Should `textmate-goto-file' keep a local cache of files?"
+  :group 'textmate.el
+  :type 'boolean)
 
-(defvar textmate-completing-library 'ido
+;; TODO: make this an alist type, so the user can specify his own
+;; function
+(defcustom textmate-completing-library 'ido
   "The library `textmade-goto-symbol' and `textmate-goto-file' should use for
-completing filenames and symbols (`ido' by default)")
+completing filenames and symbols (`ido' by default)"
+  :group 'textmate.el
+  :type '(radio (const ido)
+                (const icicles)
+                (const none)))
 
 (defvar *textmate-completing-function-alist* '((ido ido-completing-read)
                                                (icicles  icicle-completing-read)
@@ -169,7 +187,11 @@ completing filenames and symbols (`ido' by default)")
 (defvar *textmate-project-files* '()
   "Used internally to cache the files in a project.")
 
-(defcustom textmate-word-characters "a-zA-Z0-9_" "Word Characters for Column Movement")
+(defcustom textmate-word-characters
+  "a-zA-Z0-9_"
+  "Word Characters for Column Movement"
+  :group 'textmate.el
+  :type 'string)
 
 ;;; Bindings
 

--- a/textmate.el
+++ b/textmate.el
@@ -69,7 +69,7 @@
 ;;; Needed for projects
 (require 'eproject)
 
-;;; Minor mode
+;;; Configurable variables
 
 (defvar *textmate-gf-exclude*
   "(/|^)(\\.+[^/]+|vendor|fixtures|tmp|log|classes|build)($|/)|(\\.xcodeproj|\\.nib|\\.framework|\\.app|\\.pbproj|\\.pbxproj|\\.xcode|\\.xcodeproj|\\.bundle|\\.pyc)(/|$)"
@@ -170,6 +170,7 @@ completing filenames and symbols (`ido' by default)")
   "Used internally to cache the files in a project.")
 
 (defcustom textmate-word-characters "a-zA-Z0-9_" "Word Characters for Column Movement")
+
 ;;; Bindings
 
 (defun textmate-ido-fix ()
@@ -415,6 +416,8 @@ A place is considered `tab-width' character columns."
   (unless mark-active (progn (push-mark (point))
                              (setq mark-active t transient-mark-mode t)))
   (let (deactivate-mark) (textmate-column-down arg)))
+
+;;; Minor mode
 
 ;;;###autoload
 (define-minor-mode textmate-mode "TextMate Emulation Minor Mode"


### PR DESCRIPTION
Hey Chris,

As promised, here is a pull request that implements textmate.el's project functionality in terms of eproject.  It ended up being very clean; no changes were necessary to eproject, and any user configuration of textmate.el will still continue to work.  There is also no longer any dependency on running shell commands; everything is Pure Elisp (tm). The only change is that we now ignore completion-ignored-extensions in addition to _textmate-gf-exclude_.  (From a code perspective, #'textmate-project-files and #'textmate-project-root are now defaliased to the corresponding eproject functions.  There are also some functions and variables that aren't used anywhere else that I removed; if you think people are using those outside of textmate.el, then we should add those back.)

I included a commit that makes eproject a submodule for easy dependency management.  It is up to you if you want to do it this way, I have no opinion one way or the other.  I try to keep eproject master stable, so tying users to a vetted commit may not be necessary.

One minor problem is that loading textmate.el will mess up existing users' eproject projects if the _textmate-project-roots_ variable contains a file that their own rules match, as it is tried first (since it's loaded last).  But they can just customize that variable, and then everything will work again.  (eproject comes with a default rule to match .git projects, for example.  Loading textmate.el will cause a .git project to be called a textmate-project instead of a generic-git project, which results in different hooks being run, etc.)

I think there were some other issues that I thought of but I've forgotten them now :)

Anyway, try it out and if stuff is broken, I will fix.

--Jon
