### PR TITLE
Too slow textmate-goto-file when the project files' number is big.

### DIFF
--- a/textmate.el
+++ b/textmate.el
@@ -304,8 +304,8 @@ Symbols matching the text at point are put first in the completion list."
        "Find file: "
        (mapcar
 	(lambda (e)
-	  (replace-regexp-in-string (textmate-project-root) "" e))
-	(textmate-cached-project-files (textmate-project-root))))))))
+	  (replace-regexp-in-string root "" e))
+	(textmate-cached-project-files root)))))))
 
 (defun textmate-clear-cache ()
   "Clears the project root and project files cache. Use after adding files."


### PR DESCRIPTION
Test it on my Mac emacs. after use the new version, "A-t" will quickly get the result in the mini-buffer.
